### PR TITLE
Use fetchurl rather than nix-prefetch-url.

### DIFF
--- a/lib/bundix.rb
+++ b/lib/bundix.rb
@@ -11,8 +11,14 @@ class Bundix
   NIX_INSTANTIATE = 'nix-instantiate'
   NIX_PREFETCH_URL = 'nix-prefetch-url'
   NIX_PREFETCH_GIT = 'nix-prefetch-git'
+  NIX_BUILD = 'nix-build'
   NIX_HASH = 'nix-hash'
   NIX_SHELL = 'nix-shell'
+
+  FETCHURL_FORCE = File.expand_path('../bundix/fetchurl-force.nix', __FILE__)
+  FETCHURL_FORCE_CHECK = lambda do |_, out|
+    out =~ /success! failing outer nix build.../
+  end
 
   SHA256_32 = %r(^[a-z0-9]{52}$)
   SHA256_16 = %r(^[a-f0-9]{64}$)
@@ -110,9 +116,9 @@ class Bundix
     end
   end
 
-  def self.sh(*args)
+  def self.sh(*args, &block)
     out, status = Open3.capture2e(*args)
-    unless status.success?
+    unless block_given? ? block.call(status, out) : status.success?
       puts "$ #{args.join(' ')}" if $VERBOSE
       puts out if $VERBOSE
       fail "command execution failed: #{status}"

--- a/lib/bundix/fetchurl-force.nix
+++ b/lib/bundix/fetchurl-force.nix
@@ -1,0 +1,27 @@
+{ nixpkgs ? import <nixpkgs> {}
+, url
+}:
+        
+with nixpkgs;
+
+# (ab)use fetchurl to download a URL and add it to the nix store
+# *without* already knowing its hash.
+fetchurl {
+  inherit url;
+  sha256 = "0000000000000000000000000000000000000000000000000000";
+  downloadToTemp = true;
+  postFetch = ''
+    PATH="$PATH:${stdenv.lib.makeBinPath [ nix ]}"
+
+    sha256="$(nix-hash --base32 --type sha256 --flat "$downloadedFile")"
+    printf "%s\n" "$sha256"
+
+    file="$(dirname "$downloadedFile")/$(basename "$url")"
+    mv "$downloadedFile" "$file"
+    echo "adding to nix store..."
+    nix-store --add "$file"
+
+    echo "success! failing outer nix build..."
+    exit 1
+  '';
+}

--- a/lib/bundix/source.rb
+++ b/lib/bundix/source.rb
@@ -12,13 +12,13 @@ class Bundix
       end
     end
 
-    def sh(*args)
-      Bundix.sh(*args)
+    def sh(*args, &block)
+      Bundix.sh(*args, &block)
     end
 
-    def nix_prefetch_url(*args)
-      sh(NIX_PREFETCH_URL, '--type', 'sha256', *args)
-      .force_encoding('UTF-8')
+    def nix_prefetch_url(url)
+      sh(NIX_BUILD, '--argstr', 'url', url, FETCHURL_FORCE, &FETCHURL_FORCE_CHECK)
+        .force_encoding('UTF-8')
     rescue
       nil
     end


### PR DESCRIPTION
This allows taking advantage of fetchurl's support for additional curl
options through the NIX_CURL_FLAGS environment variable, which can be
used to provide credentials for a private gemserver.

See https://github.com/manveru/bundix/issues/6
