### PR TITLE
Fix: Pass custom gemfile to Bundler

### DIFF
--- a/bin/bundix
+++ b/bin/bundix
@@ -96,12 +96,13 @@ if options[:init]
   end
 end
 
+ENV['BUNDLE_GEMFILE'] = options[:gemfile]
+
 if options[:lock]
   lock = !File.file?(options[:lockfile])
   lock ||= File.mtime(options[:gemfile]) > File.mtime(options[:lockfile])
   if lock
     ENV.delete('BUNDLE_PATH')
-    ENV.delete('BUNDLE_GEMFILE')
     ENV.delete('BUNDLE_FROZEN')
     ENV.delete('BUNDLE_BIN_PATH')
     system('bundle', 'lock')


### PR DESCRIPTION
Commit message:

> Previously, a custom gemfile specified by "--gemfile" wasn't passed to
> Bundler, resulting in a Bundler error while parsing the lockfile:
> bundler.rb:212:in `rescue in root': Could not locate Gemfile or .bundle/ directory (Bundler::GemfileNotFound)

Feel free to modify the patch and commit it by yourself.