### PR TITLE
Set gemset.nix file permissions: 0644

### DIFF
--- a/lib/bundix/commandline.rb
+++ b/lib/bundix/commandline.rb
@@ -158,6 +158,7 @@ class Bundix
         tempfile.write(object2nix(gemset))
         tempfile.flush
         FileUtils.cp(tempfile.path, options[:gemset])
+        FileUtils.chmod(0644, options[:gemset])
       ensure
         tempfile.close!
         tempfile.unlink

--- a/lib/bundix/commandline.rb
+++ b/lib/bundix/commandline.rb
@@ -153,12 +153,11 @@ class Bundix
     end
 
     def save_gemset(gemset)
-      tempfile = Tempfile.new('gemset.nix', encoding: 'UTF-8')
+      tempfile = Tempfile.create('gemset.nix', encoding: 'UTF-8', mode: 0644)
       begin
         tempfile.write(object2nix(gemset))
         tempfile.flush
         FileUtils.cp(tempfile.path, options[:gemset])
-        FileUtils.chmod(0644, options[:gemset])
       ensure
         tempfile.close!
         tempfile.unlink

--- a/lib/bundix/commandline.rb
+++ b/lib/bundix/commandline.rb
@@ -153,11 +153,12 @@ class Bundix
     end
 
     def save_gemset(gemset)
-      tempfile = Tempfile.create('gemset.nix', encoding: 'UTF-8', mode: 0644)
+      tempfile = Tempfile.new('gemset.nix', encoding: 'UTF-8')
       begin
         tempfile.write(object2nix(gemset))
         tempfile.flush
         FileUtils.cp(tempfile.path, options[:gemset])
+        FileUtils.chmod(0644, options[:gemset])
       ensure
         tempfile.close!
         tempfile.unlink


### PR DESCRIPTION
The tempfile used within [save_gemset](https://github.com/manveru/bundix/blob/87c2f9181df888004f716754190550de906b8d27/lib/bundix/commandline.rb#L155-L156) is created [with permissions 0600](https://ruby-doc.org/stdlib-2.4.3/libdoc/tempfile/rdoc/Tempfile.html#method-c-new), and this results in a gemset.nix that's only readable by the file owner.

This can be problematic in certain cases. For example, I used bundix to package a gem in an overlay that's part of my nixos configuration, and is thus owned by root. As a non-root user, I added a `nixpkgs-overlays` entry to my NIX_PATH and tried to invoke nix-shell with access to the gem. This failed due to a lack of read permissions:
```
nix-shell -p ruby my-gem
error: opening file '/etc/nixos/path/to/my-gem/gemset.nix': Permission denied
```

Changing the permissions to 0644 fixes this issue, and matches the Gemfile.lock file permissions.

I'm assuming the 0600 permissions were an artifact of `Tempfile.new()` rather than a deliberate decision, but let me know if that's not the case.

I tested the `FileUtils.chmod` call manually. I'm not sure how/whether to write an automated test for this change. If you have a suggestion about how to do so I'd be happy to give it a try.