### PR TITLE
fix shell.nix: sha256 -> source.sha256

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -5,7 +5,7 @@ let
     gemName = "minitest";
     type = "gem";
     version = "5.10.1";
-    sha256 = "1yk2m8sp0p5m1niawa3ncg157a4i0594cg7z91rzjxv963rzrwab";
+    source.sha256 = "1yk2m8sp0p5m1niawa3ncg157a4i0594cg7z91rzjxv963rzrwab";
     gemPath = [];
   };
 
@@ -14,7 +14,7 @@ let
     gemName = "rake";
     type = "gem";
     version = "12.0.0";
-    sha256 = "01j8fc9bqjnrsxbppncai05h43315vmz9fwg28qdsgcjw9ck1d7n";
+    source.sha256 = "01j8fc9bqjnrsxbppncai05h43315vmz9fwg28qdsgcjw9ck1d7n";
     gemPath = [];
   };
 in


### PR DESCRIPTION
Attempts to run nix-shell were failing:
```
$ nix-shell
error: attribute 'source' missing, at /nix/store/xxx-nixos-18.09pre135256.6c064e6b1f3/nixos/pkgs/development/ruby-modules/gem/default.nix:60:18
```

Maybe this depends on the nix version? I'm running nix 2.0 on nixos 18.03