### PR TITLE
Allow source urls without password

### DIFF
--- a/lib/bundix/source.rb
+++ b/lib/bundix/source.rb
@@ -20,7 +20,7 @@ class Bundix
       warn "Downloading #{file} from #{url}"
       uri = URI(url)
       open_options = {}
-      if uri.user && uri.password
+      if uri.user
         open_options[:http_basic_authentication] = [uri.user, uri.password]
         uri.user = nil
         uri.password = nil


### PR DESCRIPTION
There are instances where a source URL does not have a password, but does include a username. I ran into this issue where private gemfury packages require `https://XXXX@gemfury.io/` as the source and not `https://XXXX:YYYY@gemfury.io/`. These sources will currently fail on master.

Unfortunately I couldn't find documentation on the behaviour of having:
```
open_options[:http_basic_authentication] = [uri.user, nil]
```
But I tested this change on the mentioned gemfury urls and is working nicely.