### PR TITLE
use XDG_CACHE_HOME if set

### DIFF
--- a/lib/bundix/source.rb
+++ b/lib/bundix/source.rb
@@ -22,7 +22,7 @@ class Bundix
     end
 
     def nix_prefetch_url(url)
-      dir = File.expand_path('~/.cache/bundix')
+      dir = File.join(ENV['XDG_CACHE_HOME'] || "#{ENV['HOME']}/.cache", 'bundix')
       FileUtils.mkdir_p dir
       file = File.join(dir, url.gsub(/[^\w-]+/, '_'))
 


### PR DESCRIPTION
There were no existing cache path tests. Is this is sufficient? Closes #34.

```
$ echo $XDG_CACHE_HOME
/home/pnelson/var/cache
$ irb
>> File.join(ENV['XDG_CACHE_HOME'] || "#{ENV['HOME']}/.cache", 'bundix')
=> "/home/pnelson/var/cache/bundix"

$ unset XDG_CACHE_HOME
$ irb
>> File.join(ENV['XDG_CACHE_HOME'] || "#{ENV['HOME']}/.cache", 'bundix')
=> "/home/pnelson/.cache/bundix"
```