### PR TITLE
Include ERb files in gem

### DIFF
--- a/bundix.gemspec
+++ b/bundix.gemspec
@@ -9,8 +9,8 @@ Gem::Specification.new do |s|
   s.description = 'Creates Nix packages from Gemfiles.'
   s.authors     = ["Michael 'manveru' Fellinger"]
   s.files       = Dir['bin/*'] +
-                  Dir['lib/**/*.{rb,nix}'] +
-                  Dir['template/**/*.{rb,nix}']
+                  Dir['lib/**/*.{rb,nix,erb}'] +
+                  Dir['template/**/*.{rb,nix,erb}']
   s.bindir      = 'bin'
   s.executables = ['bundix']
   s.add_runtime_dependency 'bundler', '~> 1.11'


### PR DESCRIPTION
The gem was broken without these:

> No such file or directory @ rb_sysopen - /nix/store/45rcjqqszj5jzlh1mwlxgkx7j410p7pv-bundix-2.4.0/lib/ruby/gems/2.5.0/gems/bundix-2.4.0/template/nixer/set.erb (Errno::ENOENT)

This means that bundix has been unusable in nixpkgs since 2.4.0 was released.