### PR TITLE
remove the --leave-dotGit to restore reproducability

### DIFF
--- a/lib/bundix/source.rb
+++ b/lib/bundix/source.rb
@@ -75,7 +75,7 @@ class Bundix
     def nix_prefetch_git(uri, revision)
       home = ENV['HOME']
       ENV['HOME'] = '/homeless-shelter'
-      sh(NIX_PREFETCH_GIT, '--url', uri, '--rev', revision, '--hash', 'sha256', '--leave-dotGit')
+      sh(NIX_PREFETCH_GIT, '--url', uri, '--rev', revision, '--hash', 'sha256')
     ensure
       ENV['HOME'] = home
     end


### PR DESCRIPTION
This seems to have caused a lot of headache for the metasploit maintainers. We don't need the `.git` anymore since we create a fake repo during the gem build now anyway.