### PR TITLE
Don't capture stderr from Nix

### DIFF
--- a/lib/bundix.rb
+++ b/lib/bundix.rb
@@ -173,7 +173,7 @@ class Bundix
   end
 
   def self.sh(*args, &block)
-    out, status = Open3.capture2e(*args)
+    out, status = Open3.capture2(*args)
     unless block_given? ? block.call(status, out) : status.success?
       puts "$ #{args.join(' ')}" if $VERBOSE
       puts out if $VERBOSE


### PR DESCRIPTION
If Nix produces warnings, we probably shouldn't eat them, and we
/definitely/ shouldn't put them in the same string as the output,
which we then try to parse as JSON.

Fixes https://github.com/nix-community/bundix/issues/59.

Cc: @flokli