### PR TITLE
Fix gemset generation for Gem version including the platform requirement

### DIFF
--- a/lib/bundix.rb
+++ b/lib/bundix.rb
@@ -85,10 +85,19 @@ class Bundix
     {platforms: platforms}
   end
 
+  def version(spec)
+    platform = spec.platform
+    if platform == Gem::Platform::RUBY || platform.nil?
+      spec.version.to_s
+    else
+      "#{spec.version}-#{platform}"
+    end
+  end
+
   def convert_spec(spec, cache, dep_cache)
     {
       spec.name => {
-        version: spec.version.to_s,
+        version: version(spec),
         source: Source.new(spec, fetcher).convert
       }.merge(platforms(spec, dep_cache)).merge(groups(spec, dep_cache))
     }

--- a/test/convert.rb
+++ b/test/convert.rb
@@ -40,6 +40,7 @@ class TestConvert < Minitest::Test
     ) do |gemset|
       assert_equal("0.5.0", gemset.dig("bundler-audit", :version))
       assert_equal("0.19.4", gemset.dig("thor", :version))
+      assert_equal("0.4.4821-universal-darwin-14", gemset.dig("sorbet-static", :version))
     end
   end
 end

--- a/test/data/bundler-audit/Gemfile
+++ b/test/data/bundler-audit/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org' do
   gem 'bundler-audit'
+  gem 'sorbet', '= 0.4.4821'
 end

--- a/test/data/bundler-audit/Gemfile.lock
+++ b/test/data/bundler-audit/Gemfile.lock
@@ -4,6 +4,9 @@ GEM
     bundler-audit (0.5.0)
       bundler (~> 1.2)
       thor (~> 0.18)
+    sorbet (0.4.4821)
+      sorbet-static (= 0.4.4821)
+    sorbet-static (0.4.4821-universal-darwin-14)
     thor (0.19.4)
 
 PLATFORMS
@@ -11,6 +14,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler-audit!
+  sorbet (= 0.4.4821)!
 
 BUNDLED WITH
    1.12.5


### PR DESCRIPTION
Some gems like [sorbet-static](https://rubygems.org/gems/sorbet-static) or [sys-proctable](https://rubygems.org/gems/sys-proctable) (< 1.2) compose their version number by appending the platform cpu, os and version.

For example, the following `Gemfile`:

```ruby
source 'https://rubygems.org' do
  gem 'sorbet', '= 0.4.4821'
end
```

Gives the following `Gemfile.lock`:

```
GEM
  remote: https://rubygems.org/
  specs:
    sorbet (0.4.4821)
      sorbet-static (= 0.4.4821)
    sorbet-static (0.4.4821-universal-darwin-14)

PLATFORMS
  ruby

DEPENDENCIES
  sorbet (= 0.4.4821)!

BUNDLED WITH
   1.12.5
```

But will produce the following `gemset.nix` file with `bundix`:

```nix
{
  sorbet = {
    dependencies = ["sorbet-static"];
    groups = ["development" "test"];
    platforms = [];
    source = {
      remotes = ["https://rubygems.org"];
      sha256 = "099nvhim356rvg0rmx71lnr74fy0rbh6m51fzknwsb59dskn0nrg";
      type = "gem";
    };
    version = "0.4.4821";
  };
  sorbet-static = {
    groups = ["default" "development" "test"];
    platforms = [];
    source = {
      remotes = ["https://rubygems.org"];
      sha256 = "0v0ldhw7wqh9554l002lz7vzqjhkcqwhnr3k14c85fqwmrfixhxm";
      type = "gem";
    };
    version = "0.4.4821";
  };
}
```

Notice how the platform specified in the `Gemfile.lock` for `sorbet-static` is lost when the `gemset.nix` is generated. From `0.4.4821-universal-darwin-14` to `0.4.4821`.

This is a problem since the package manager for NixOs only relies on the `version` attribute to download the required gem (code copied from https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/ruby-modules/gem/default.nix#L56-L62): 

```nix
    if type == "gem" then
      fetchurl {
        urls = map (
          remote: "${remote}/gems/${gemName}-${version}.gem"
        ) (attrs.source.remotes or [ "https://rubygems.org" ]);
        inherit (attrs.source) sha256;
      }
```

This pull-request appends the platform to the compiled `gemset.nix` file so we get:

```nix
{
  sorbet-static = {
    groups = ["default" "development" "test"];
    platforms = [];
    source = {
      remotes = ["https://rubygems.org"];
      sha256 = "0v0ldhw7wqh9554l002lz7vzqjhkcqwhnr3k14c85fqwmrfixhxm";
      type = "gem";
    };
    version = "0.4.4834-universal-darwin-14";
  };
}
```

And the NixOS package manager is happy.