### PR TITLE
Add support for platform-dependant pre-compiled gems

### DIFF
--- a/lib/bundix.rb
+++ b/lib/bundix.rb
@@ -87,10 +87,12 @@ class Bundix
 
   def convert_spec(spec, cache, dep_cache)
     {
-      spec.name => {
-        version: spec.version.to_s,
-        source: Source.new(spec, fetcher).convert
-      }.merge(platforms(spec, dep_cache)).merge(groups(spec, dep_cache))
+      spec.name => [
+        { version: spec.version.to_s },
+        platforms(spec, dep_cache),
+        groups(spec, dep_cache),
+        Source.new(spec, fetcher).convert,
+      ].inject(&:merge),
     }
   rescue => ex
     warn "Skipping #{spec.name}: #{ex}"

--- a/lib/bundix.rb
+++ b/lib/bundix.rb
@@ -88,7 +88,6 @@ class Bundix
   def convert_spec(spec, cache, dep_cache)
     {
       spec.name => [
-        { version: spec.version.to_s },
         platforms(spec, dep_cache),
         groups(spec, dep_cache),
         Source.new(spec, fetcher).convert,

--- a/lib/bundix/source.rb
+++ b/lib/bundix/source.rb
@@ -92,11 +92,20 @@ class Bundix
     end
 
     def fetch_local_hash(spec)
-      spec.source.caches.each do |cache|
-        path = File.join(cache, "#{spec.full_name}.gem")
-        next unless File.file?(path)
+      has_platform = spec.platform && spec.platform != Gem::Platform::RUBY
+      name_version = "#{spec.name}-#{spec.version}"
+      filename = has_platform ? "#{name_version}-*" : name_version
+
+      paths = spec.source.caches.map(&:to_s)
+      Dir.glob("{#{paths.join(',')}}/#{filename}.gem").each do |path|
+        if has_platform
+          # Find first gem that matches the platform
+          platform = File.basename(path, '.gem')[(name_version.size + 1)..-1]
+          next unless Gem::Platform.match(platform)
+        end
+
         hash = nix_prefetch_url(path)[SHA256_32]
-        return format_hash(hash) if hash
+        return format_hash(hash), platform if hash
       end
 
       nil
@@ -104,22 +113,37 @@ class Bundix
 
     def fetch_remotes_hash(spec, remotes)
       remotes.each do |remote|
-        hash = fetch_remote_hash(spec, remote)
-        return remote, format_hash(hash) if hash
+        hash, platform = fetch_remote_hash(spec, remote)
+        return remote, format_hash(hash), platform if hash
       end
 
       nil
     end
 
     def fetch_remote_hash(spec, remote)
+      has_platform = spec.platform && spec.platform != Gem::Platform::RUBY
+      if has_platform
+        # Fetch remote spec to determine the exact platform
+        # Note that we can't simply use the local platform; the platform of the gem might differ.
+        # e.g. universal-darwin-14 covers x86_64-darwin-14
+        spec = spec_for_dependency(remote, spec.name, spec.version)
+        return unless spec
+      end
+
       uri = "#{remote}/gems/#{spec.full_name}.gem"
       result = nix_prefetch_url(uri)
       return unless result
-      result[SHA256_32]
+
+      return result[SHA256_32], spec.platform&.to_s
     rescue => e
       puts "ignoring error during fetching: #{e}"
       puts e.backtrace
       nil
+    end
+
+    def spec_for_dependency(remote, name, version)
+      sources = Gem::SourceList.from([remote])
+      Gem::SpecFetcher.new(sources).spec_for_dependency(Gem::Dependency.new(name, version)).first&.first&.first
     end
   end
 
@@ -150,11 +174,14 @@ class Bundix
 
     def convert_rubygems
       remotes = spec.source.remotes.map{|remote| remote.to_s.sub(/\/+$/, '') }
-      hash = fetcher.fetch_local_hash(spec)
-      remote, hash = fetcher.fetch_remotes_hash(spec, remotes) unless hash
+      hash, platform = fetcher.fetch_local_hash(spec)
+      remote, hash, platform = fetcher.fetch_remotes_hash(spec, remotes) unless hash
       fail "couldn't fetch hash for #{spec.full_name}" unless hash
 
       version = spec.version.to_s
+      if platform && platform != Gem::Platform::RUBY
+        version += "-#{platform}"
+      end
 
       puts "#{hash} => #{spec.name}-#{version}.gem" if $VERBOSE
 

--- a/lib/bundix/source.rb
+++ b/lib/bundix/source.rb
@@ -140,8 +140,10 @@ class Bundix
 
     def convert_path
       {
-        type: "path",
-        path: spec.source.path
+        source: {
+          type: 'path',
+          path: spec.source.path,
+        },
       }
     end
 
@@ -152,9 +154,13 @@ class Bundix
       fail "couldn't fetch hash for #{spec.full_name}" unless hash
       puts "#{hash} => #{spec.full_name}.gem" if $VERBOSE
 
-      { type: 'gem',
-        remotes: (remote ? [remote] : remotes),
-        sha256: hash }
+      {
+        source: {
+          type: 'gem',
+          remotes: (remote ? [remote] : remotes),
+          sha256: hash,
+        },
+      }
     end
 
     def convert_git
@@ -167,11 +173,15 @@ class Bundix
       fail "couldn't fetch hash for #{spec.full_name}" unless hash
       puts "#{hash} => #{uri}" if $VERBOSE
 
-      { type: 'git',
-        url: uri.to_s,
-        rev: revision,
-        sha256: hash,
-        fetchSubmodules: submodules }
+      {
+        source: {
+          type: 'git',
+          url: uri.to_s,
+          rev: revision,
+          sha256: hash,
+          fetchSubmodules: submodules,
+        },
+      }
     end
   end
 end

--- a/lib/bundix/source.rb
+++ b/lib/bundix/source.rb
@@ -140,6 +140,7 @@ class Bundix
 
     def convert_path
       {
+        version: spec.version.to_s,
         source: {
           type: 'path',
           path: spec.source.path,
@@ -152,9 +153,13 @@ class Bundix
       hash = fetcher.fetch_local_hash(spec)
       remote, hash = fetcher.fetch_remotes_hash(spec, remotes) unless hash
       fail "couldn't fetch hash for #{spec.full_name}" unless hash
-      puts "#{hash} => #{spec.full_name}.gem" if $VERBOSE
+
+      version = spec.version.to_s
+
+      puts "#{hash} => #{spec.name}-#{version}.gem" if $VERBOSE
 
       {
+        version: version,
         source: {
           type: 'gem',
           remotes: (remote ? [remote] : remotes),
@@ -174,6 +179,7 @@ class Bundix
       puts "#{hash} => #{uri}" if $VERBOSE
 
       {
+        version: spec.version.to_s,
         source: {
           type: 'git',
           url: uri.to_s,

--- a/test/convert.rb
+++ b/test/convert.rb
@@ -40,6 +40,7 @@ class TestConvert < Minitest::Test
     ) do |gemset|
       assert_equal("0.5.0", gemset.dig("bundler-audit", :version))
       assert_equal("0.19.4", gemset.dig("thor", :version))
+      assert_equal("0.4.4821", gemset.dig("sorbet-static", :version))
     end
   end
 end

--- a/test/convert.rb
+++ b/test/convert.rb
@@ -1,23 +1,23 @@
 require 'minitest/autorun'
 require 'bundix'
+require 'digest'
+require 'json'
 
 class TestConvert < Minitest::Test
-  class PrefetchStub
+  class PrefetchStub < Bundix::Fetcher
     def nix_prefetch_url(*args)
-      return "nix_prefetch_url_hash"
+      format_hash(Digest::SHA256.hexdigest(args.to_s))
     end
 
-    def nix_prefetch_git(uri, revision)
-      return '{"sha256": "nix_prefetch_git_hash"}'
+    def nix_prefetch_git(*args)
+      JSON.generate("sha256" => format_hash(Digest::SHA256.hexdigest(args.to_s)))
     end
 
     def fetch_local_hash(spec)
-      return "5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03" #taken from `man nix-hash`
+      # Force to use fetch_remote_hash
+      return nil
     end
 
-    def fetch_remotes_hash(spec, remotes)
-      return "fetch_remotes_hash_hash"
-    end
   end
 
   def with_gemset(options)

--- a/test/data/bundler-audit/Gemfile
+++ b/test/data/bundler-audit/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org' do
   gem 'bundler-audit'
+  gem 'sorbet', '= 0.4.4821'
 end

--- a/test/data/bundler-audit/Gemfile.lock
+++ b/test/data/bundler-audit/Gemfile.lock
@@ -5,12 +5,16 @@ GEM
       bundler (~> 1.2)
       thor (~> 0.18)
     thor (0.19.4)
+    sorbet (0.4.4821)
+      sorbet-static (= 0.4.4821)
+    sorbet-static (0.4.4821-universal-darwin-14)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   bundler-audit!
+  sorbet (= 0.4.4821)!
 
 BUNDLED WITH
    1.12.5


### PR DESCRIPTION
For example:
```rb
# Gemfile
source 'https://rubygems.org' do
  gem 'sorbet', '= 0.4.4821'
end
```
```
# Gemfile.lock
GEM
  remote: https://rubygems.org/
  specs:
    sorbet (0.4.4821)
      sorbet-static (= 0.4.4821)
    sorbet-static (0.4.4821-universal-darwin-14)
# ...
```
```nix
# gemset.nix
{
  sorbet = {
    dependencies = ["sorbet-static"];
    groups = ["default"];
    platforms = [];
    source = {
      remotes = ["https://rubygems.org"];
      sha256 = "0nci20x5vqd2q9pvykmam05xv95j7zsxxcj5favjb2knfk6z5jq4";
      type = "gem";
    };
    version = "0.4.4821";
  };
  sorbet-static = {
    groups = ["default"];
    platforms = [];
    source = {
      remotes = ["https://rubygems.org"];
      sha256 = "0lxw6il82h5m7syy0sswgd7k0hjr5kxvdm59s2kkbjsh8wdn1rnp";
      type = "gem";
    };
    version = "0.4.4821";
  };
}
```
```sh
$ bundix -l
[4.3 MiB DL]
path is '/nix/store/hlxbn8cnvpiaf8szz59cn93y9d6lz8a6-sorbet-static-0.4.4821-universal-darwin-14.gem'
0lxw6il82h5m7syy0sswgd7k0hjr5kxvdm59s2kkbjsh8wdn1rnp => sorbet-static-0.4.4821-universal-darwin-14.gem
# ...
```

---

### Problem 1 - download url
Trying to start a shell with that would result in the wrong gem url trying to be downloaded:
```
trying https://rubygems.org/gems/sorbet-static-0.4.4821.gem
curl: (22) The requested URL returned error: 403 Forbidden
error: cannot download sorbet-static-0.4.4821.gem from any mirror
```
The URL should include the platform; namely https://rubygems.org/gems/sorbet-static-0.4.4821-universal-darwin-14.gem

This is what https://github.com/nix-community/bundix/pull/67 was attempting to fix.

### Problem 2 - sha256
The version recorded in the `gemset.nix` ends up being for whatever platform recorded was in the `Gemfile.lock`. In practice, we need to download a gem that is compatible with our current platform.

Knowing the exact platform of a compiled gem is important because we need the correct URL _and_ different binaries have different hashes.

### Changes in this PR

- Add sorbet to bundler-audit because it depends on a platform-dependant gem
- Change the mock fetcher in tests to extend a real fetcher
- Refactor Bundix::Source to return a hash one-level above
- When we detect that a gem has a platform, check available versions (local or remote) for a matching platform.
- Add the platform in the version recorded in the gemset

PR is broken down in smaller commits for easier review

Superseeds https://github.com/nix-community/bundix/pull/67; this PR doesn't assume that the gem exists with a version for the exact local platform. Instead, it finds the first matching platform in available gems.

### Testing the PR
(With Gemfile above)

```sh
$ nix run nixpkgs.ruby -c /path/to/bundix -l
```
```nix
# default.nix
with (import <nixpkgs> {});
let
  gems = bundlerEnv {
    name = "test";
    inherit ruby;
    gemdir = ./.;
  };
in stdenv.mkDerivation {
  name = "test";
  buildInputs = [gems ruby];
}
```
```
$ nix-shell
[nix-shell:~]$ bundler list --paths
/nix/store/njz4hkf3cx2rzapdwds0rbzvzpcdwv97-test/lib/ruby/gems/2.6.0/gems/sorbet-0.4.4821
/nix/store/njz4hkf3cx2rzapdwds0rbzvzpcdwv97-test/lib/ruby/gems/2.6.0/gems/sorbet-static-0.4.4821-universal-darwin-17
```

### Known caveats

1. This PR makes the gemset platform dependant.
2. The platform is detected based on the ruby that executes `bundix`

/cc @burke @morriar