### PR TITLE
Feature/builtins fetchgit

### DIFF
--- a/lib/bundix.rb
+++ b/lib/bundix.rb
@@ -12,6 +12,7 @@ require_relative 'bundix/nixer'
 class Bundix
   NIX_INSTANTIATE = 'nix-instantiate'
   NIX_PREFETCH_URL = 'nix-prefetch-url'
+  GIT = 'git'
   NIX_HASH = 'nix-hash'
   NIX_SHELL = 'nix-shell'
 

--- a/lib/bundix.rb
+++ b/lib/bundix.rb
@@ -3,7 +3,6 @@ require 'json'
 require 'open-uri'
 require 'open3'
 require 'pp'
-require 'tmpdir'
 
 require_relative 'bundix/version'
 require_relative 'bundix/source'
@@ -12,7 +11,6 @@ require_relative 'bundix/nixer'
 class Bundix
   NIX_INSTANTIATE = 'nix-instantiate'
   NIX_PREFETCH_URL = 'nix-prefetch-url'
-  GIT = 'git'
   NIX_HASH = 'nix-hash'
   NIX_SHELL = 'nix-shell'
 

--- a/lib/bundix.rb
+++ b/lib/bundix.rb
@@ -3,6 +3,7 @@ require 'json'
 require 'open-uri'
 require 'open3'
 require 'pp'
+require 'tmpdir'
 
 require_relative 'bundix/version'
 require_relative 'bundix/source'
@@ -11,7 +12,6 @@ require_relative 'bundix/nixer'
 class Bundix
   NIX_INSTANTIATE = 'nix-instantiate'
   NIX_PREFETCH_URL = 'nix-prefetch-url'
-  NIX_PREFETCH_GIT = 'nix-prefetch-git'
   NIX_HASH = 'nix-hash'
   NIX_SHELL = 'nix-shell'
 

--- a/lib/bundix/commandline.rb
+++ b/lib/bundix/commandline.rb
@@ -107,7 +107,7 @@ class Bundix
         fail unless system(
           Bundix::NIX_SHELL, '-p', options[:ruby],
           "bundler.override { ruby = #{options[:ruby]}; }",
-          "--command", "bundle pack --all --path #{options[:bundle_pack_path]}")
+          "--command", "bundle pack --path #{options[:bundle_pack_path]}")
       end
     end
 

--- a/lib/bundix/source.rb
+++ b/lib/bundix/source.rb
@@ -163,7 +163,7 @@ class Bundix
         url: uri.to_s,
         rev: revision,
         ref: ref,
-        fetchSubmodules: submodules }
+        submodules: submodules }
     end
   end
 end

--- a/shell.nix
+++ b/shell.nix
@@ -34,11 +34,11 @@ in
     mkdir -p $out
     makeWrapper $src/bin/bundix $out/bin/bundix \
       --prefix PATH : "${nix.out}/bin" \
-      --prefix PATH : "${nix-prefetch-git.out}/bin" \
+      --prefix PATH : "${git.out}/bin" \
       --set GEM_PATH "${bundler}/${bundler.ruby.gemPath}"
   '';
 
   nativeBuildInputs = [makeWrapper];
 
-  buildInputs = [bundler ruby minitest rake nix-prefetch-scripts];
+  buildInputs = [bundler ruby minitest rake git];
 }

--- a/shell.nix
+++ b/shell.nix
@@ -34,11 +34,10 @@ in
     mkdir -p $out
     makeWrapper $src/bin/bundix $out/bin/bundix \
       --prefix PATH : "${nix.out}/bin" \
-      --prefix PATH : "${git.out}/bin" \
       --set GEM_PATH "${bundler}/${bundler.ruby.gemPath}"
   '';
 
   nativeBuildInputs = [makeWrapper];
 
-  buildInputs = [bundler ruby minitest rake git];
+  buildInputs = [bundler ruby minitest rake];
 }


### PR DESCRIPTION
This hopefully solves https://github.com/nix-community/bundix/issues/69

~Works in tandem with https://github.com/kraem/nixpkgs/blob/bb4b2da585dd0186b3c1cec9fb9f7f9227cf428c/pkgs/development/ruby-modules/gem/default.nix#L67-L70
I'll create a PR in `nixpkgs` for that as soon as this has been reviewed and approved :+1:~

**edit**
~Apparently the bin wrappers in `nixpkgs` for gems needs some more work before this is ready. The gems gets installed, but in in the wrong path in `/nix/store`.~
**/edit**

**edit2**
Now works in tandem with [this fork `nixpkgs`](https://github.com/kraem/nixpkgs/commits/kraem/nixos/bundler-env/new-type). Haven't tried with private git gems that have executables yet.
**/edit2**

The responsibility for fetching the repo and calculating a `sha256` is now transfered to `nix`'s `builtins.fetchGit` which doesn't do it in a sandbox but can use the current users `ssh` credentials.

All gems fetched from git now gets the type `buitlins-git`, but the old type `git` is saved in `bundlerEnv` for backwards compatibility.

Thanks a lot for your time to explain how all of this fits together @manveru

I haven't written many lines ruby before so I'm sure there are a lot of things that could look nicer.