### PR TITLE
Allowing direct execution of the bundler if already in the shell

### DIFF
--- a/lib/bundix/commandline.rb
+++ b/lib/bundix/commandline.rb
@@ -100,14 +100,14 @@ class Bundix
       ENV['BUNDLE_GEMFILE'] = options[:gemfile]
 
       if options[:magic]
-        fail unless system(
-          Bundix::NIX_SHELL, '-p', options[:ruby],
-          "bundler.override { ruby = #{options[:ruby]}; }",
-          "--command", "bundle lock --lockfile=#{options[:lockfile]}")
-        fail unless system(
-          Bundix::NIX_SHELL, '-p', options[:ruby],
-          "bundler.override { ruby = #{options[:ruby]}; }",
-          "--command", "bundle pack --all --path #{options[:bundle_pack_path]}")
+        prefix =
+          if ENV['IN_NIX_SHELL']
+            []
+          else
+            [Bundix::NIX_SHELL, '-p', options[:ruby], "bundler.override { ruby = #{options[:ruby]}; }", "--command"]
+          end
+        fail unless system(*prefix, "bundle lock --lockfile=#{options[:lockfile]}")
+        fail unless system(*prefix, "bundle pack --path #{options[:bundle_pack_path]}")
       end
     end
 

--- a/lib/bundix/source.rb
+++ b/lib/bundix/source.rb
@@ -20,7 +20,7 @@ class Bundix
       end
 
       begin
-        open(uri.to_s, 'r', 0600, open_options) do |net|
+        URI.open(uri.to_s, 'r', 0600, open_options) do |net|
           File.open(file, 'wb+') { |local|
             File.copy_stream(net, local)
           }


### PR DESCRIPTION
Might be useful in cases, when custom ruby interpreter is used (not in nixpkgs). So it is not (easily) possible to pass it into subsequent shell.

P.S. It might be a good idea to detect which version of bundler bundix is using, because 2.x does not support `--all` flag.