### PR TITLE
Fix fetching under Ruby 3.0

### DIFF
--- a/lib/bundix/source.rb
+++ b/lib/bundix/source.rb
@@ -20,7 +20,7 @@ class Bundix
       end
 
       begin
-        open(uri.to_s, 'r', 0600, open_options) do |net|
+        URI.open(uri.to_s, 'r', 0600, open_options) do |net|
           File.open(file, 'wb+') { |local|
             File.copy_stream(net, local)
           }


### PR DESCRIPTION
Ruby 2.7 deprecated using open for URIs, and recommends using URI.open
instead.

    warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open

As of Ruby 3.0 the options argument is gone and bundix skips over http
fetches.

Additional context: https://bugs.ruby-lang.org/issues/15893#note-2

Example error:

    Downloading /Users/lorne/.cache/bundix/https_rubygems_org_gems_debase-ruby_core_source-0_10_12_gem from https://rubygems.org/gems/debase-ruby_core_source-0.10.12.gem
    wrong number of arguments (given 4, expected 1..3)
    Skipping debase-ruby_core_source: couldn't fetch hash for debase-ruby_core_source-0.10.12