### PR TITLE
Multi platform

### DIFF
--- a/lib/bundix.rb
+++ b/lib/bundix.rb
@@ -87,10 +87,12 @@ class Bundix
 
   def convert_spec(spec, cache, dep_cache)
     {
-      spec.name => {
-        version: spec.version.to_s,
-        source: Source.new(spec, fetcher).convert
-      }.merge(platforms(spec, dep_cache)).merge(groups(spec, dep_cache))
+      spec.name => [
+        { version: spec.version.to_s },
+        platforms(spec, dep_cache),
+        groups(spec, dep_cache),
+        Source.new(spec, fetcher).convert,
+      ].inject(&:merge),
     }
   rescue => ex
     warn "Skipping #{spec.name}: #{ex}"

--- a/lib/bundix.rb
+++ b/lib/bundix.rb
@@ -88,7 +88,6 @@ class Bundix
   def convert_spec(spec, cache, dep_cache)
     {
       spec.name => [
-        { version: spec.version.to_s },
         platforms(spec, dep_cache),
         groups(spec, dep_cache),
         Source.new(spec, fetcher).convert,

--- a/lib/bundix.rb
+++ b/lib/bundix.rb
@@ -183,7 +183,11 @@ class Bundix
   end
 
   def parse_lockfile
-    Bundler::LockfileParser.new(File.read(options[:lockfile]))
+    lock = Bundler::LockfileParser.new(File.read(options[:lockfile]))
+    if !lock.platforms.include?(target_platform)
+      raise KeyError, "#{target_platform} not listed in gemfile. Try `bundle lock --add-platform #{target_platform}`"
+    end
+    lock
   end
 
   def self.sh(*args, &block)

--- a/lib/bundix.rb
+++ b/lib/bundix.rb
@@ -44,6 +44,7 @@ class Bundix
     lock.specs.group_by(&:name).each.with_object({}) do |(name, specs), gems|
       # reverse so git/plain-ruby sources come last
       spec = specs.reverse.find {|s| s.platform == Gem::Platform::RUBY || s.platform =~ target_platform }
+      next unless spec
       gem = find_cached_spec(spec, cache) || convert_spec(spec, cache, dep_cache)
       gems.merge!(gem)
 

--- a/lib/bundix.rb
+++ b/lib/bundix.rb
@@ -84,7 +84,16 @@ class Bundix
       PLATFORM_MAPPING[platform_name.to_s]
     end.flatten
 
-    {platforms: platforms}
+    # 'platforms' is the Bundler DSL for including a gem if we're on a certain platform.
+    # 'target_platform' is the platform that bundix is currently resolving gem-specs for.
+    # 'gem_platform' is the platform of the resulting spec.
+    # (eg we might be resolving gem-specs for x86_64-darwin, but if there's not a suitable
+    # precompiled gem available, then gem_platform will just be 'ruby')
+    {
+      platforms: platforms,
+      target_platform: target_platform.to_s,
+      gem_platform: spec.platform.to_s,
+    }
   end
 
   def convert_spec(spec, cache, dep_cache)
@@ -105,6 +114,7 @@ class Bundix
     name, cached = cache.find{|k, v|
       next unless k == spec.name
       next unless cached_source = v['source']
+      next unless target_platform.to_s == v['target_platform']
 
       case spec_source = spec.source
       when Bundler::Source::Git

--- a/lib/bundix/commandline.rb
+++ b/lib/bundix/commandline.rb
@@ -15,7 +15,8 @@ class Bundix
       gemfile: 'Gemfile',
       lockfile: 'Gemfile.lock',
       gemset: 'gemset.nix',
-      project: File.basename(Dir.pwd)
+      project: File.basename(Dir.pwd),
+      platform: 'ruby'
     }
 
     def self.run
@@ -65,6 +66,10 @@ class Bundix
 
         o.on "--gemfile=#{options[:gemfile]}", 'path to the Gemfile' do |value|
           options[:gemfile] = File.expand_path(value)
+        end
+
+        o.on "--platform=#{options[:platform]}", 'platform version to use' do |value|
+          options[:platform] = value
         end
 
         o.on '-d', '--dependencies', 'include gem dependencies (deprecated)' do

--- a/lib/bundix/source.rb
+++ b/lib/bundix/source.rb
@@ -92,11 +92,20 @@ class Bundix
     end
 
     def fetch_local_hash(spec)
-      spec.source.caches.each do |cache|
-        path = File.join(cache, "#{spec.full_name}.gem")
-        next unless File.file?(path)
+      has_platform = spec.platform && spec.platform != Gem::Platform::RUBY
+      name_version = "#{spec.name}-#{spec.version}"
+      filename = has_platform ? "#{name_version}-*" : name_version
+
+      paths = spec.source.caches.map(&:to_s)
+      Dir.glob("{#{paths.join(',')}}/#{filename}.gem").each do |path|
+        if has_platform
+          # Find first gem that matches the platform
+          platform = File.basename(path, '.gem')[(name_version.size + 1)..-1]
+          next unless Gem::Platform.match(platform)
+        end
+
         hash = nix_prefetch_url(path)[SHA256_32]
-        return format_hash(hash) if hash
+        return format_hash(hash), platform if hash
       end
 
       nil
@@ -104,22 +113,37 @@ class Bundix
 
     def fetch_remotes_hash(spec, remotes)
       remotes.each do |remote|
-        hash = fetch_remote_hash(spec, remote)
-        return remote, format_hash(hash) if hash
+        hash, platform = fetch_remote_hash(spec, remote)
+        return remote, format_hash(hash), platform if hash
       end
 
       nil
     end
 
     def fetch_remote_hash(spec, remote)
+      has_platform = spec.platform && spec.platform != Gem::Platform::RUBY
+      if has_platform
+        # Fetch remote spec to determine the exact platform
+        # Note that we can't simply use the local platform; the platform of the gem might differ.
+        # e.g. universal-darwin-14 covers x86_64-darwin-14
+        spec = spec_for_dependency(remote, spec.name, spec.version)
+        return unless spec
+      end
+
       uri = "#{remote}/gems/#{spec.full_name}.gem"
       result = nix_prefetch_url(uri)
       return unless result
-      result[SHA256_32]
+
+      return result[SHA256_32], spec.platform&.to_s
     rescue => e
       puts "ignoring error during fetching: #{e}"
       puts e.backtrace
       nil
+    end
+
+    def spec_for_dependency(remote, name, version)
+      sources = Gem::SourceList.from([remote])
+      Gem::SpecFetcher.new(sources).spec_for_dependency(Gem::Dependency.new(name, version)).first&.first&.first
     end
   end
 
@@ -150,11 +174,14 @@ class Bundix
 
     def convert_rubygems
       remotes = spec.source.remotes.map{|remote| remote.to_s.sub(/\/+$/, '') }
-      hash = fetcher.fetch_local_hash(spec)
-      remote, hash = fetcher.fetch_remotes_hash(spec, remotes) unless hash
+      hash, platform = fetcher.fetch_local_hash(spec)
+      remote, hash, platform = fetcher.fetch_remotes_hash(spec, remotes) unless hash
       fail "couldn't fetch hash for #{spec.full_name}" unless hash
 
       version = spec.version.to_s
+      if platform && platform != Gem::Platform::RUBY
+        version += "-#{platform}"
+      end
 
       puts "#{hash} => #{spec.name}-#{version}.gem" if $VERBOSE
 

--- a/lib/bundix/source.rb
+++ b/lib/bundix/source.rb
@@ -140,8 +140,10 @@ class Bundix
 
     def convert_path
       {
-        type: "path",
-        path: spec.source.path
+        source: {
+          type: 'path',
+          path: spec.source.path,
+        },
       }
     end
 
@@ -152,9 +154,13 @@ class Bundix
       fail "couldn't fetch hash for #{spec.full_name}" unless hash
       puts "#{hash} => #{spec.full_name}.gem" if $VERBOSE
 
-      { type: 'gem',
-        remotes: (remote ? [remote] : remotes),
-        sha256: hash }
+      {
+        source: {
+          type: 'gem',
+          remotes: (remote ? [remote] : remotes),
+          sha256: hash,
+        },
+      }
     end
 
     def convert_git
@@ -167,11 +173,15 @@ class Bundix
       fail "couldn't fetch hash for #{spec.full_name}" unless hash
       puts "#{hash} => #{uri}" if $VERBOSE
 
-      { type: 'git',
-        url: uri.to_s,
-        rev: revision,
-        sha256: hash,
-        fetchSubmodules: submodules }
+      {
+        source: {
+          type: 'git',
+          url: uri.to_s,
+          rev: revision,
+          sha256: hash,
+          fetchSubmodules: submodules,
+        },
+      }
     end
   end
 end

--- a/lib/bundix/source.rb
+++ b/lib/bundix/source.rb
@@ -140,6 +140,7 @@ class Bundix
 
     def convert_path
       {
+        version: spec.version.to_s,
         source: {
           type: 'path',
           path: spec.source.path,
@@ -152,9 +153,13 @@ class Bundix
       hash = fetcher.fetch_local_hash(spec)
       remote, hash = fetcher.fetch_remotes_hash(spec, remotes) unless hash
       fail "couldn't fetch hash for #{spec.full_name}" unless hash
-      puts "#{hash} => #{spec.full_name}.gem" if $VERBOSE
+
+      version = spec.version.to_s
+
+      puts "#{hash} => #{spec.name}-#{version}.gem" if $VERBOSE
 
       {
+        version: version,
         source: {
           type: 'gem',
           remotes: (remote ? [remote] : remotes),
@@ -174,6 +179,7 @@ class Bundix
       puts "#{hash} => #{uri}" if $VERBOSE
 
       {
+        version: spec.version.to_s,
         source: {
           type: 'git',
           url: uri.to_s,

--- a/test/convert.rb
+++ b/test/convert.rb
@@ -40,6 +40,7 @@ class TestConvert < Minitest::Test
     ) do |gemset|
       assert_equal("0.5.0", gemset.dig("bundler-audit", :version))
       assert_equal("0.19.4", gemset.dig("thor", :version))
+      assert_equal("0.4.4821", gemset.dig("sorbet-static", :version))
     end
   end
 end

--- a/test/convert.rb
+++ b/test/convert.rb
@@ -1,23 +1,23 @@
 require 'minitest/autorun'
 require 'bundix'
+require 'digest'
+require 'json'
 
 class TestConvert < Minitest::Test
-  class PrefetchStub
+  class PrefetchStub < Bundix::Fetcher
     def nix_prefetch_url(*args)
-      return "nix_prefetch_url_hash"
+      format_hash(Digest::SHA256.hexdigest(args.to_s))
     end
 
-    def nix_prefetch_git(uri, revision)
-      return '{"sha256": "nix_prefetch_git_hash"}'
+    def nix_prefetch_git(*args)
+      JSON.generate("sha256" => format_hash(Digest::SHA256.hexdigest(args.to_s)))
     end
 
     def fetch_local_hash(spec)
-      return "5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03" #taken from `man nix-hash`
+      # Force to use fetch_remote_hash
+      return nil
     end
 
-    def fetch_remotes_hash(spec, remotes)
-      return "fetch_remotes_hash_hash"
-    end
   end
 
   def with_gemset(options)

--- a/test/convert.rb
+++ b/test/convert.rb
@@ -25,13 +25,13 @@ class TestConvert < Minitest::Test
       return nil
     end
 
-    def spec_for_dependency(remote, name, version)
-      opts = SPECS[name]
+    def spec_for_dependency(remote, spec)
+      opts = SPECS[spec.name]
       raise "Unexpected spec query: #{name}" unless opts
 
       Gem::Specification.new do |s|
-        s.name = name
-        s.version = version
+        s.name = spec.name
+        s.version = spec.version
         s.platform = Gem::Platform.new(opts[:platform]) if opts[:platform]
       end
     end

--- a/test/convert.rb
+++ b/test/convert.rb
@@ -53,7 +53,19 @@ class TestConvert < Minitest::Test
   def test_bundler_dep
     with_gemset(
       :gemfile => File.expand_path("data/bundler-audit/Gemfile", __dir__),
-      :lockfile => File.expand_path("data/bundler-audit/Gemfile.lock", __dir__)
+      :lockfile => File.expand_path("data/bundler-audit/Gemfile.lock", __dir__),
+    ) do |gemset|
+      assert_equal("0.5.0", gemset.dig("bundler-audit", :version))
+      assert_equal("0.19.4", gemset.dig("thor", :version))
+      refute(gemset.has_key?("sorbet-static"))
+    end
+  end
+
+  def test_platform_specific_lookups
+    with_gemset(
+      :gemfile => File.expand_path("data/bundler-audit/Gemfile", __dir__),
+      :lockfile => File.expand_path("data/bundler-audit/Gemfile.lock", __dir__),
+      :platform => 'java'
     ) do |gemset|
       assert_equal("0.5.0", gemset.dig("bundler-audit", :version))
       assert_equal("0.19.4", gemset.dig("thor", :version))

--- a/test/data/bundler-audit/Gemfile
+++ b/test/data/bundler-audit/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org' do
   gem 'bundler-audit'
+  gem 'sorbet', '= 0.4.4821'
 end

--- a/test/data/bundler-audit/Gemfile.lock
+++ b/test/data/bundler-audit/Gemfile.lock
@@ -5,12 +5,16 @@ GEM
       bundler (~> 1.2)
       thor (~> 0.18)
     thor (0.19.4)
+    sorbet (0.4.4821)
+      sorbet-static (= 0.4.4821)
+    sorbet-static (0.4.4821-universal-darwin-14)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   bundler-audit!
+  sorbet (= 0.4.4821)!
 
 BUNDLED WITH
    1.12.5

--- a/test/data/bundler-audit/Gemfile.lock
+++ b/test/data/bundler-audit/Gemfile.lock
@@ -7,9 +7,11 @@ GEM
     thor (0.19.4)
     sorbet (0.4.4821)
       sorbet-static (= 0.4.4821)
+    sorbet-static (0.4.4821-java)
     sorbet-static (0.4.4821-universal-darwin-14)
 
 PLATFORMS
+  java
   ruby
 
 DEPENDENCIES


### PR DESCRIPTION
This builds on top of @lavoiesl's awesome work here https://github.com/nix-community/bundix/pull/68 - but hopefully gets rid of the main objections raised in that PR

By default bundix will generate more-or-less the same gemset as it always has, though each gem gets a couple of new keys to help with tracking: eg:

```diff
   nokogiri = {
     dependencies = ["mini_portile2" "racc"];
+    gem_platform = "ruby";
     groups = ["assets" "default" "development" "test"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "05rfzi8wksps5pgaavq1n1vkngsrjhqz8rcd1qdb52hnpg9q9p9b";
       type = "gem";
     };
+    target_platform = "ruby";
     version = "1.11.4";
   };
```

You can also specify a platform to generate the gemset for - eg `bundix --platform=x86_64-darwin-19`, which will fetch the native gems for x86_64-darwin-19 where available:

```diff
   nokogiri = {
-    dependencies = ["mini_portile2" "racc"];
+    dependencies = ["racc"];
+    gem_platform = "x86_64-darwin";
     groups = ["assets" "default" "development" "test"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "05rfzi8wksps5pgaavq1n1vkngsrjhqz8rcd1qdb52hnpg9q9p9b";
+      sha256 = "0cyp98db8wpcp108w1b4iwh6ah98cwdydz2g2f5jlsig3qnf2m91";
       type = "gem";
     };
-    version = "1.11.4";
+    target_platform = "x86_64-darwin-19";
+    version = "1.11.4-x86_64-darwin";
   };
```

That's probably fine if all your developers are on the same platform, but if you need multiplatform support, there's also a new `--platforms` option.  `bundix --platforms=ruby,x86_64-darwin,x86_64-linux,aarch64-darwin` generates 4 gemsets (gemset.nix, gemset.x86_64-darwin.nix, gemset.x86_64-linux.nix, & gemset.aarch64-darwin.nix), targetted at the different platforms.


Caveats:

* You need to run `bundle lock --add-platform FOO` before Bundix will look up the corresponding platform's gems. (Possibly the `--platforms=ruby,x86_64-linux` option should be replaced with, eg, `--autoplatforms`, which generates a gemset for each platform that's referenced in your Gemfile.lock ...)

* Subtle platform mismatches can lead to confusing bundler errors. I generated a gemset with `bundix --platform=x86_64-darwin`, which fetched x86_64-darwin-20 gems. Bundler then fails to load with "Could not find libv8-node-15.14.0.1 in any of the sources", because it tries to find the x86_64-darwin-19 version. Seems to be bundler-specific, though - loading the gem using a simple require works fine 😕 .  And if I regenerate the gemset with `bundix --platform=x86_64-darwin19`, that also works fine - at least on x86_64-darwin-19 ruby...

* I'm not sure of a good nixy way of selecting which gemset to load in bundlerEnv.  I was using this, till I ran into the above problem of needing to include the specific version number:
```nix
pkgs.bundlerEnv {
  gemset = import ./gemset + ".${ruby.system}.nix";
```