### PR TITLE
Properly set groups based on dependencies

### DIFF
--- a/lib/bundix.rb
+++ b/lib/bundix.rb
@@ -42,7 +42,7 @@ class Bundix
 
     # reverse so git comes last
     lock.specs.reverse_each.with_object({}) do |spec, gems|
-      gem = find_cached_spec(spec, cache) || convert_spec(spec, cache, dep_cache)
+      gem = find_cached_spec(spec, cache, dep_cache) || convert_spec(spec, cache, dep_cache)
       gems.merge!(gem)
 
       if spec.dependencies.any?
@@ -98,7 +98,7 @@ class Bundix
     {spec.name => {}}
   end
 
-  def find_cached_spec(spec, cache)
+  def find_cached_spec(spec, cache, dep_cache)
     name, cached = cache.find{|k, v|
       next unless k == spec.name
       next unless cached_source = v['source']
@@ -115,7 +115,13 @@ class Bundix
       end
     }
 
-    {name => cached} if cached
+    if cached
+      updated = cached.slice('source', 'version')
+        .merge(groups(spec, dep_cache))
+        .merge(platforms(spec, dep_cache))
+
+      { name => updated }
+    end
   end
 
   def build_depcache(lock)

--- a/lib/bundix.rb
+++ b/lib/bundix.rb
@@ -127,7 +127,7 @@ class Bundix
     end
 
     lock.specs.each do |spec|
-      dep_cache[spec.name] ||= Dependency.new(spec.name, nil, {})
+      dep_cache[spec.name] ||= Dependency.new(spec.name, nil, { "group" => [] })
     end
 
     begin
@@ -143,7 +143,7 @@ class Bundix
             dep_cache[name] = Dependency.new(name, lock.bundler_version, {})
           end
 
-          if !((as_dep.groups - cached.groups) - [:default]).empty? or !(as_dep.platforms - cached.platforms).empty?
+          if !(as_dep.groups - cached.groups).empty? or !(as_dep.platforms - cached.platforms).empty?
             changed = true
             dep_cache[cached.name] = (Dependency.new(cached.name, nil, {
               "group" => as_dep.groups | cached.groups,


### PR DESCRIPTION
Bundix incorrectly adds the `default` group to gems in the lock file but not in the gem file.

A Gemfile like
```
source 'https://rubygems.org'

gem 'rspec', group: :test
```
will result in `rspec` having the group `test`, but its dependencies (`rspec-mocks`, etc) will have both `default` and `test`.

Incidentally, this PR also fixes https://github.com/nix-community/bundix/issues/39