### PR TITLE
Add flake support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,42 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1656928814,
+        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1658873576,
+        "narHash": "sha256-cyJ4ezCbuTslEsZgxe4XS1ZZrdBVqt2yUjeLrh59ioQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c7532da9f81671548d62d5065b50dd9200ec9952",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,25 @@
+{
+  description = "Bundix makes it easy to package your Bundler-enabled Ruby applications with the Nix package manager";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in {
+        packages = {
+          default = import ./default.nix {
+            inherit pkgs;
+
+            # The ruby_2_7 attribute is used here because the ruby_2_6 attribute used in
+            # default.nix is no longer available in more recent versions of Nixpkgs
+            ruby = pkgs.ruby_2_7;
+          };
+        };
+      }
+    );
+}


### PR DESCRIPTION
This PR adds flake support for this repo. This has been tested only on `aarch64-darwin` but I don't see any reason to suspect that it would present issues on the other "default" systems (as per `flake-utils`). I've verified that `nix run` works as expected in multiple projects with `Gemfile.lock` available.