### PR TITLE
set GEM_HOME to allow repo as flake input

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -16,6 +16,7 @@ pkgs.stdenv.mkDerivation rec {
       --prefix PATH : "${nix.out}/bin" \
       --prefix PATH : "${nix-prefetch-git.out}/bin" \
       --prefix PATH : "${bundler.out}/bin" \
+      --set GEM_HOME "${bundler}/${bundler.ruby.gemPath}" \
       --set GEM_PATH "${bundler}/${bundler.ruby.gemPath}"
   '';
 


### PR DESCRIPTION
Sets `GEM_HOME`, which allows this repository's default.nix to be used as a flake input with Ruby 3.x:

Setting `GEM_HOME` is also performed in [the nixpkgs build](https://github.com/NixOS/nixpkgs/blob/nixos-22.11/pkgs/development/ruby-modules/bundix/default.nix#L26)

Example use within a flake using this PR, using the nixpkgs-ruby to override:

```nix
{
  inputs = {
    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.11";
    nixpkgs-ruby.url = "github:bobvanderlinden/nixpkgs-ruby";
    nixpkgs-ruby.inputs.nixpkgs.follows = "nixpkgs";
    flake-utils.url = "github:numtide/flake-utils";
    bundix-src = {
      url = "github:cscorley/bundix/add-gem-home";
      flake = false;
    };
  };

  outputs = { self, nixpkgs, nixpkgs-ruby, flake-utils, bundix-src }:
    flake-utils.lib.eachDefaultSystem (system:
      let
        pkgs = nixpkgs.legacyPackages.${system};
        rubyVersion = nixpkgs.lib.strings.removePrefix "ruby-"
          (nixpkgs.lib.fileContents ./.ruby-version);
        ruby = nixpkgs-ruby.packages.${system}."ruby-${rubyVersion}";

        gems = pkgs.bundlerEnv {
          name = "gemset";
          inherit ruby;
          gemfile = ./Gemfile;
          lockfile = ./Gemfile.lock;
          gemset = ./gemset.nix;
          groups = [ "default" "production" "development" "test" ];
        };

        # Override bundix to use the later ruby
        bundler = pkgs.bundler.override { inherit ruby; };
        bundix = pkgs.callPackage bundix-src { inherit pkgs ruby bundler; };
      in {
        devShells.default =
          pkgs.mkShell { buildInputs = [ gems ruby bundix ]; };
      });
}
```