### PR TITLE
Fixes a few issues that prevented bundix from running for me:

### DIFF
--- a/lib/bundix.rb
+++ b/lib/bundix.rb
@@ -1,6 +1,7 @@
 require 'bundler'
+require 'fileutils'
 require 'json'
-require 'open-uri'
+require 'net/http'
 require 'open3'
 require 'pp'
 


### PR DESCRIPTION
1. Better exception tracing in `nix_prefetch_url`: Like in #96, I was seeing "wrong number of arguments (given 4, expected 1..3)". I couldn't figure out where this was coming from, so I changed the exception handler in `nix_prefetch_url` to print the exception's `full_message`, which includes the backtrace.

2. Parallel to `nix_prefetch_url` failing, the code in `fetch_local_hash` is intolerant of that function returning nil. I also amended the `[SHA256_32]` to only run when non-nil.

3. Finally, the root issue with the 4 args instead of 1..3 was because of the invocation of `open`. Since this API is generally discouraged anyway, I just rewrote this code to use NET::HTTP and FileUtils.