### PR TITLE
Fix pre bundled downloads

### DIFF
--- a/lib/bundix/source.rb
+++ b/lib/bundix/source.rb
@@ -19,8 +19,14 @@ class Bundix
         uri.password = nil
       end
 
+      open_args = [uri.to_s, 'r', 0600]
+
+      unless [nil, 'file'].include?(uri.scheme)
+        open_args <<= open_options
+      end
+
       begin
-        URI.open(uri.to_s, 'r', 0600, open_options) do |net|
+        URI.open(*open_args) do |net|
           File.open(file, 'wb+') { |local|
             File.copy_stream(net, local)
           }


### PR DESCRIPTION
When running bundix I experienced, that it tries to "download" pre bundled gems from filesystem. Since signatures of URI.open and its fallback to Kernel.open are different, this throws an exception.