### PR TITLE
ruby_3_0 fix for downloading files locally

### DIFF
--- a/lib/bundix/source.rb
+++ b/lib/bundix/source.rb
@@ -20,10 +20,15 @@ class Bundix
       end
 
       begin
-        URI.open(uri.to_s, 'r', 0600, open_options) do |net|
+        copy = proc do |net|
           File.open(file, 'wb+') { |local|
             File.copy_stream(net, local)
           }
+        end
+        if File.size?(url)
+          URI.open(uri.to_s, 'r', 0600, &copy) 
+        else
+          URI.open(uri.to_s, 'r', 0600, open_options, &copy) 
         end
       rescue OpenURI::HTTPError => e
         # e.message: "403 Forbidden" or "401 Unauthorized"


### PR DESCRIPTION
for gems that are downloaded from local disk eg `rexml`

`URI.open(uri.to_s, 'r', 0600, open_options`  for local files with raise exception 

```
URI.open '/nix/store/nkvkb0rzrbaf6sn52llhl33l31pjf7nn-ruby-3.0.6/lib/ruby/gems/3.0.0/cache/rexml-3.2.5.gem', 'r', 0600, {}
/nix/store/nkvkb0rzrbaf6sn52llhl33l31pjf7nn-ruby-3.0.6/lib/ruby/3.0.0/open-uri.rb:31:in `initialize': wrong number of arguments (given 4, expected 1..3) (ArgumentError)
from /nix/store/nkvkb0rzrbaf6sn52llhl33l31pjf7nn-ruby-3.0.6/lib/ruby/3.0.0/open-uri.rb:31:in `open'
from /nix/store/nkvkb0rzrbaf6sn52llhl33l31pjf7nn-ruby-3.0.6/lib/ruby/3.0.0/open-uri.rb:31:in `open'

```