### PR TITLE
Add redirection support

### DIFF
--- a/test/fetcher_test.rb
+++ b/test/fetcher_test.rb
@@ -8,7 +8,7 @@ class Bundix
   class FetcherTest < MiniTest::Test
     def test_download_with_credentials
       with_dir(bundler_credential: 'secret') do |dir|
-        with_server(returning_content: 'ok') do |port|
+        with_server do |port|
           file = 'some-file'
 
           assert_equal(File.realpath(dir), Bundler.root.to_s)
@@ -27,7 +27,7 @@ class Bundix
 
     def test_download_without_credentials
       with_dir(bundler_credential: nil) do |dir|
-        with_server(returning_content: 'ok') do |port|
+        with_server do |port|
           file = 'some-file'
 
           assert_equal(File.realpath(dir), Bundler.root.to_s)
@@ -43,6 +43,43 @@ class Bundix
         end
       end
     end
+
+    def test_handle_redirection_response
+      with_dir(bundler_credential: nil) do |dir|
+        build_responses = ->(port) {
+          [
+            {
+              route: "/test/redirection",
+              returning_content: 'You are being redirected',
+              returning_status: "302 Found",
+              returning_headers: ["Location: http://127.0.0.1:#{port}/test"]
+            },
+            {
+              route: "/test",
+              returning_content: 'ok',
+              returning_status: "200 OK",
+              returning_headers: []
+            }
+          ]
+        }
+
+        with_server(build_responses) do |port|
+          file = 'some-file'
+
+          assert_equal(File.realpath(dir), Bundler.root.to_s)
+
+          out, err = capture_io do
+            Bundix::Fetcher.new.download(file, "http://127.0.0.1:#{port}/test/redirection")
+          end
+
+          assert_equal(File.read(file), 'ok')
+          assert_empty(out)
+          assert_match(/^Downloading .* from http.*$/, err)
+          assert_match(/^Redirected to http.*$/, err)
+        end
+      end
+    end
+
     private
 
     def with_dir(bundler_credential:)
@@ -61,28 +98,34 @@ class Bundix
       end
     end
 
-    def with_server(returning_content:)
+    def with_server(build_responses = ->(port) { [{ route: "/test", returning_content: 'ok', returning_status: "200 OK", returning_headers: [] }] })
       server = TCPServer.new('127.0.0.1', 0)
       port_num = server.addr[1]
 
-      @request = ''
+      responses = build_responses.call(port_num)
 
       Thread.abort_on_exception = true
       thr = Thread.new do
-        conn = server.accept
-        until (line = conn.readline) == "\r\n"
-          @request << line
+        responses.length.times.each do
+          conn = server.accept
+          @request = ''
+
+          until (line = conn.readline) == "\r\n"
+            @request << line
+          end
+
+          response = responses.find { |r| r[:route] == @request.split(' ')[1] }
+
+          conn.write(
+            "HTTP/1.1 #{response[:returning_status]}\r\n" \
+            "Content-Length: #{response[:returning_content].length}\r\n" \
+            "Content-Type: text/plain\r\n" \
+            "#{response[:returning_headers].map { |h| "#{h}\r\n" }.join("")}" \
+            "\r\n" \
+            "#{response[:returning_content]}",
+          )
+          conn.close
         end
-
-        conn.write(
-          "HTTP/1.1 200 OK\r\n" \
-          "Content-Length: #{returning_content.length}\r\n" \
-          "Content-Type: text/plain\r\n" \
-          "\r\n" \
-          "#{returning_content}",
-        )
-
-        conn.close
       end
 
       yield(port_num)


### PR DESCRIPTION
Fixes #106

This PR adds support for HTTPRedirection responses from servers that use CDNs, like Github private package repositories

The tests could be a lot cleaner if we were to use a library or framework to mock the HTTP requests and responses instead of running our own fake server.