### PR TITLE
Add support for platform windows

### DIFF
--- a/lib/bundix.rb
+++ b/lib/bundix.rb
@@ -68,6 +68,7 @@ class Bundix
     "mingw" => [{engine: "mingw"}],
     "truffleruby" => [{engine: "ruby"}],
     "x64_mingw" => [{engine: "mingw"}],
+    "windows" => [{engine: "mswin"}, {engine: "mswin64"}, {engine: "mingw"}],
   }.each do |name, list|
     PLATFORM_MAPPING[name] = list
     %w(1.8 1.9 2.0 2.1 2.2 2.3 2.4 2.5 2.6).each do |version|

--- a/lib/bundix.rb
+++ b/lib/bundix.rb
@@ -80,7 +80,7 @@ class Bundix
   def platforms(spec, dep_cache)
     # c.f. Bundler::CurrentRuby
     platforms = dep_cache.fetch(spec.name).platforms.map do |platform_name|
-      PLATFORM_MAPPING[platform_name.to_s]
+      PLATFORM_MAPPING.fetch platform_name.to_s
     end.flatten
 
     {platforms: platforms}


### PR DESCRIPTION
Fixes https://github.com/nix-community/bundix/issues/57

Several gems declare platform support for `windows`, including several dependencies of a newly-generated `rails` app

* debug (1.9.1)
* io-console (0.7.2)
* irb (1.11.1)
* psych (5.1.2)
* rdoc (6.6.2)
* reline (0.4.2)
* stringio (3.1.0)
