### PR TITLE
Enable fetching of private git repos. When fetching git repos, use bundler credentials if they exist.

### DIFF
--- a/test/inject_credentials_from_bundler_settings_test.rb
+++ b/test/inject_credentials_from_bundler_settings_test.rb
@@ -1,0 +1,61 @@
+require 'minitest/autorun'
+require 'bundix'
+
+class Bundix
+  class InjectCredentialsFromBundlerSettingsTest < MiniTest::Test
+    def subject(uri)
+      Bundix::Fetcher
+        .new
+        .inject_credentials_from_bundler_settings(uri)
+    end
+
+    def test_for_no_auth
+      uri_without_auth = URI("https://foo.com/public_repo")
+      with_bundler_config do |dir|
+        assert_equal(uri_without_auth.to_s, subject(uri_without_auth).to_s)
+      end
+    end
+
+    def test_when_auth_is_in_env_var
+      token = "secret"
+      ENV["BUNDLE_FOO__COM"] = token
+      uri = URI("https://foo.com/private_repo")
+      uri_with_auth = URI(
+        "https://#{token}@foo.com/private_repo"
+      )
+
+      with_bundler_config do |dir|
+        assert_equal(uri_with_auth, subject(uri))
+      end
+    ensure
+      ENV["BUNDLE_FOO__COM"] = nil
+    end
+
+    def test_when_auth_is_in_bundler_config
+      uri = URI("https://foo.com/private_repo")
+      token = "secret"
+      uri_with_auth = URI("https://#{token}@foo.com/private_repo")
+
+      with_bundler_config(uri: uri, auth: token) do |dir|
+        assert_equal(uri_with_auth.to_s, subject(uri).to_s)
+      end
+    end
+
+    def with_bundler_config(uri: nil, auth: nil)
+      Dir.mktmpdir do |dir|
+        File.write("#{dir}/Gemfile", 'source "https://rubygems.org"')
+
+        if uri && auth
+          key = "BUNDLE_#{uri.host.gsub(".","__").gsub("-","___").upcase}"
+          FileUtils.mkdir("#{dir}/.bundle")
+          File.write("#{dir}/.bundle/config", "---\n#{key}: #{auth}\n")
+        end
+
+        Dir.chdir(dir) do
+          Bundler.reset!
+          yield(dir)
+        end
+      end
+    end
+  end
+end

--- a/test/nix_prefetch_git_command_test.rb
+++ b/test/nix_prefetch_git_command_test.rb
@@ -1,0 +1,73 @@
+require 'minitest/autorun'
+require 'bundix'
+
+class Bundix
+  class NixPrefetchGitCommandTest < MiniTest::Test
+    def subject(uri, revision, submodules)
+      Bundix::Fetcher.new.nix_prefetch_git_command(uri, revision, submodules)
+    end
+
+    def test_for_public_repo
+      uri = URI("https://foo.com/public_repo")
+      revision = "123"
+      submodules = false
+      with_bundler_config do |_|
+        assert_equal(
+          [
+            NIX_PREFETCH_GIT,
+            "--url", "#{uri}",
+            "--rev", "#{revision}",
+            "--hash", "sha256"
+          ],
+          subject(
+            uri, revision, submodules
+          ),
+        )
+      end
+    end
+
+    def test_for_private_repo
+      token = "secret"
+      ENV["BUNDLE_FOO__COM"] = token
+      uri = URI("https://foo.com/private_repo")
+      uri_with_creds = URI(
+        "https://#{token}@foo.com/private_repo"
+      )
+      revision = "123"
+      submodules = false
+
+      with_bundler_config do |_|
+        assert_equal(
+          [
+            NIX_PREFETCH_GIT,
+            "--url", "#{uri_with_creds}",
+            "--rev", "#{revision}",
+            "--hash", "sha256"
+          ],
+          subject(
+            uri, revision, submodules
+          ),
+        )
+      end
+    ensure
+      ENV["BUNDLE_FOO__COM"] = nil
+    end
+
+    def with_bundler_config(uri: nil, auth: nil)
+      Dir.mktmpdir do |dir|
+        File.write("#{dir}/Gemfile", 'source "https://rubygems.org"')
+
+        if uri && auth
+          key = "BUNDLE_#{uri.host.gsub(".","__").gsub("-","___").upcase}"
+          FileUtils.mkdir("#{dir}/.bundle")
+          File.write("#{dir}/.bundle/config", "---\n#{key}: #{auth}\n")
+        end
+
+        Dir.chdir(dir) do
+          Bundler.reset!
+          yield(dir)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
For private repos, use credentials provided by bundler if they exist.
The credentials can be specified either via the bundler config file, or through an environment variable.

For example,  github credentials can be provider via the `BUNDLER_GITHUB__COM` environment variable or by setting the same value in the local .bundler/config file.

The credentials are then added to the uri and passed to the `nix-prefetch-git` command to fetch the repo.