### PR TITLE
Make it possible to run Bundix without Nix tools in some cases

### DIFF
--- a/lib/bundix/source.rb
+++ b/lib/bundix/source.rb
@@ -1,3 +1,5 @@
+require 'digest/sha2'
+
 class Bundix
   class Fetcher
     def sh(*args, &block)
@@ -111,7 +113,11 @@ class Bundix
       spec.source.caches.each do |cache|
         path = File.join(cache, "#{spec.full_name}.gem")
         next unless File.file?(path)
-        hash = nix_prefetch_url(path)&.[](SHA256_32)
+        hash = Digest::SHA256.file(path).digest.bytes
+          .reverse
+          .reduce(0) {|n, b| (n << 8) + b }
+          .digits(32).map {|d| "0123456789abcdfghijklmnpqrsvwxyz"[d] }.join.ljust(52, '0')
+          .reverse
         return format_hash(hash) if hash
       end
 


### PR DESCRIPTION
While working on one of my projects I found that it is useful to maintain an up-to-date copy of `Gemfile.lock` in the format of `gemset.nix` without requiring the use of Nix tools. Fortunately, all that `nix-prefetch-url` in the "flat" mode does is formatting an SHA256 hash in a weird way, which is just as easy to do with Ruby alone.